### PR TITLE
Add support for non-TLS connections for proxy environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,6 @@ let connection = try await Connection.connect(
     useTLS: false
 )
 ```
-<<<<<<< HEAD
-=======
-```
->>>>>>> bfd19d0eef3fe2d04acdbefb71b4147a52a06013
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ The channel binding policy can be configured as either:
 
 ⚠️ When using `.preferred` mode, if the connection proceeds with plain SCRAM-SHA-256 (without -PLUS), it's important to verify that the server genuinely does not support SCRAM-SHA-256-PLUS. Otherwise, a protocol downgrade attack may be possible, where an attacker strips the -PLUS mechanism to force weaker authentication.
 
+## Proxy Environment Support
+
+For database proxy environments like StrongDM, pgBouncer, or other connection poolers that handle TLS termination:
+
+```swift
+// Connect through a proxy without TLS
+let connection = try await Connection.connect(
+    host: "proxy.example.com", 
+    port: 5432, 
+    useTLS: false
+)
+```
+<<<<<<< HEAD
+=======
+```
+>>>>>>> bfd19d0eef3fe2d04acdbefb71b4147a52a06013
+
 ## Prerequisites
 
 - **Swift 5.5 or later**  (PostgresClientKit uses Swift 5.5 structured concurrency)


### PR DESCRIPTION
## Summary
This PR adds support for plain TCP connections (without TLS) to enable compatibility with database proxy services like StrongDM, pgBouncer, and other connection poolers that handle TLS/encryption on their end automatically. Some require TLS to be disabled for connections in those cases.

## Changes
- Added `useTLS` parameter to `Connection.connect()` method (defaults to `true` for backward compatibility)
- Modified `createPostgresConnection()` to conditionally use TLS based on the new parameter
- When `useTLS: false`, uses `NWParameters.tcp` instead of `NWParameters(tls: tlsOptions)`
- Uses empty certificate hash for non-TLS connections

## Use Case
Database proxy services like StrongDM handle TLS termination and authentication at the proxy level. These services expect plain PostgreSQL protocol connections without TLS negotiation or ALPN (Application-Layer Protocol Negotiation).

## Example Usage
```swift
// Standard TLS connection (existing behavior)
let connection = try await Connection.connect(host: "localhost", port: 5432)

// Plain TCP connection for proxy environments
let connection = try await Connection.connect(host: "proxy.example.com", port: 5432, useTLS: false)
```

## Backward Compatibility
- ✅ Fully backward compatible - existing code continues to work unchanged
- ✅ TLS remains the default behavior (`useTLS: true`)
- ✅ No breaking changes to existing API

## Testing
Tested with StrongDM proxy environment, confirming successful connection and query execution.
Feel free to adjust as needed, but these changes do allow my proxied connections to work successfully. Before they would get stuck on the Connection.connect() function with no errors, timeout, etc.