### PR TITLE
Make column metadata public

### DIFF
--- a/Sources/SwiftPostgresClient/Connection+direct.swift
+++ b/Sources/SwiftPostgresClient/Connection+direct.swift
@@ -36,8 +36,8 @@ extension Connection {
         }
         let queryRequest = QueryRequest(query: sql)
         try await sendRequest(queryRequest)
-        try await receiveResponse(type: RowDescriptionResponse.self)
+        let rowDesc = try await receiveResponse(type: RowDescriptionResponse.self)
         let response = await receiveResponse()
-        return ResultCursor(connection: self, portalName: "", extendedProtocol: false, initialResponse: response)
+        return ResultCursor(connection: self, portalName: "", extendedProtocol: false, metadata: rowDesc.columns, initialResponse: response)
     }
 }

--- a/Sources/SwiftPostgresClient/Portal.swift
+++ b/Sources/SwiftPostgresClient/Portal.swift
@@ -28,7 +28,9 @@ import Foundation
 public struct Portal: Sendable {
     
     let name: String
-    let metadata: [ColumnMetadata]?
+    /// Column metadata for this portal, if available.
+    /// Pass `columnMetadata: true` to `PreparedStatement.bind()` to populate this.
+    public let metadata: [ColumnMetadata]?
     let statement: Statement
     unowned let connection: Connection
     

--- a/Sources/SwiftPostgresClient/ResultCursor.swift
+++ b/Sources/SwiftPostgresClient/ResultCursor.swift
@@ -23,7 +23,9 @@ public struct ResultCursor: AsyncSequence, Sendable {
     let connection: Connection
     let portalName: String
     let extendedProtcol: Bool
-    let metatdata: [ColumnMetadata]?
+    /// Column metadata for the result set, if available.
+    /// Pass `columnMetadata: true` to `PreparedStatement.bind()` to populate this.
+    public let metatdata: [ColumnMetadata]?
     let rowDecoder: RowDecoder?
     let initialResponse: Response?
     let commandStatus: CommandStatus?


### PR DESCRIPTION
## Summary
- Make `ResultCursor.metatdata` and `Portal.metadata` public so consumers can access column names for dynamic SQL results
- Capture `RowDescriptionResponse` columns in `Connection.query(_:)` simple query path, which previously discarded them

## Motivation
When executing arbitrary SQL (e.g. in a tool that runs user-provided queries), there's no way to get column names from the result set. The metadata is already parsed from the Postgres wire protocol — it just isn't exposed publicly.

The extended query protocol path (`PreparedStatement.bind(columnMetadata: true)`) stores metadata internally for `decodeByColumnName`, but the simple query path (`connection.query(sql)`) discards the `RowDescriptionResponse` entirely.

## Changes
- `Portal.metadata`: `let` → `public let`
- `ResultCursor.metatdata`: `let` → `public let`
- `Connection.query(_:)`: capture `RowDescriptionResponse.columns` and pass to `ResultCursor`